### PR TITLE
Feature/bug fixes

### DIFF
--- a/keymaps/regex-tester.cson
+++ b/keymaps/regex-tester.cson
@@ -1,0 +1,7 @@
+'.platform-darwin':
+  'cmd-r cmd-t': 'regex-tester:show'
+  'cmd-r cmd-h': 'regex-tester:hide'
+
+'.platform-linux, .platform-win32':
+  'ctrl-r ctrl-t': 'regex-tester:show'
+  'ctrl-r ctrl-h': 'regex-tester:hide'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -14,8 +14,9 @@ module.exports = RegexTester =
   activate: (state) ->
     @createRegexView()
     @disposables = new CompositeDisposable
-    @disposables.add atom.commands.add 'atom-workspace', 'regex-tester:toggle': => @regexview.show()
+    @disposables.add atom.commands.add 'atom-workspace', 'regex-tester:show': => @regexview.show()
+    @disposables.add atom.commands.add 'atom-workspace', 'regex-tester:hide': => @regexview.hide()
 
   deactivate: ->
-    @dispoables.dispose()
+    @disposables.dispose()
     @regexview.destroy()

--- a/lib/regex-view.coffee
+++ b/lib/regex-view.coffee
@@ -65,7 +65,7 @@ module.exports =
         @regex_data.focus()
 
       @disposables = new CompositeDisposable
-      @disposables.add atom.commands.add 'atom-workspace', 'core:cancel': => @close()
+      @disposables.add atom.commands.add 'atom-workspace', 'core:cancel': => @hide()
       @disposables.add atom.tooltips.add(@global, title: 'Global Match')
       @disposables.add atom.tooltips.add(@ignore_case, title: 'Ignore Case')
       @disposables.add atom.tooltips.add(@multiline, title: 'Multiline')
@@ -85,7 +85,7 @@ module.exports =
       @panel?.destroy()
       @panel = null
 
-    close: ->
+    hide: ->
       @panel?.hide()
 
     show: ->

--- a/lib/regex-view.coffee
+++ b/lib/regex-view.coffee
@@ -15,7 +15,7 @@ module.exports =
         @div class: 'body', =>
           @div class:'block flex', =>
             @div class:'editor-item flex-editor', =>
-              @subview 'regex_data', new TextEditorView({mini: true, placeholderText:'Regular Expression'})
+              @subview 'regex_data', new TextEditorView({placeholderText:'Regular Expression'})
             @div =>
               @div id:'regex-type', class:'btn-group', =>
                 @button outlet:'regexp', class:'btn bold selected', 'RegExp'
@@ -31,7 +31,7 @@ module.exports =
                   @button outlet:'dot_all', class:'btn bold', '.'
           @div class:'block', =>
             @div class:'editor-item', =>
-              @subview 'test_data', new TextEditorView({mini:true, placeholderText:'Test Input'})
+              @subview 'test_data', new TextEditorView({placeholderText:'Test Input'})
           @div class:'output', outlet: 'output'
 
     initialize: ->
@@ -77,8 +77,6 @@ module.exports =
       @RegexEditor.onDidStopChanging => @update()
       @TestEditor.onDidStopChanging => @update()
 
-      @TestEditor.onDidChangeMini (mini) => if mini is true then @joinLines(@TestEditor) else @splitLines(@TestEditor)
-      @RegexEditor.onDidChangeMini (mini) => if mini is true then @joinLines(@RegexEditor) else @splitLines(@RegexEditor)
 
     destroy: ->
       @disposables.dispose()
@@ -92,10 +90,6 @@ module.exports =
       @panel ?= atom.workspace.addBottomPanel(item: this)
       @panel.show()
       @regex_data.focus()
-
-    setEditorMinis: (reg, test) ->
-      @RegexEditor.setMini(reg)
-      @TestEditor.setMini(test)
 
     clear: ->
       @output.html('')
@@ -124,7 +118,8 @@ module.exports =
     update: ->
       @clear()
 
-      @setEditorMinis not (@xregexp.hasClass('selected') and @free_space.hasClass('selected')), not @multiline.hasClass('selected')
+      if (@RegexEditor.getText()=="")
+        return
 
       options =
         global: @global.hasClass('selected')

--- a/menus/regex-tester.cson
+++ b/menus/regex-tester.cson
@@ -5,8 +5,12 @@
       'label': 'Regex-Tester'
       'submenu': [
         {
-          'label': 'Toggle'
-          'command': 'regex-tester:toggle'
+          'label': 'Show'
+          'command': 'regex-tester:show'
+        },
+        {
+          'label': 'Hide'
+          'command': 'regex-tester:hide'
         }
       ]
     ]

--- a/package.json
+++ b/package.json
@@ -7,9 +7,15 @@
     "regex",
     "tester"
   ],
-  "activationCommands": {
-    "atom-workspace": "regex-tester:toggle"
-  },
+  "activationCommands":
+  [
+    {
+      "atom-workspace": "regex-tester:show"
+    },
+    {
+      "atom-workspace": "regex-tester:hide"
+    }
+  ],
   "repository": "https://github.com/deprint/regex-tester",
   "license": "MIT",
   "engines": {

--- a/spec/regex-view-spec.coffee
+++ b/spec/regex-view-spec.coffee
@@ -39,7 +39,7 @@ describe 'Regex View', ->
   describe 'When setting multi-line flag', ->
 
     beforeEach ->
-      expect(view.TestEditor.isMini()).toBe true
+      expect(view.TestEditor.isMini()).toBe false
       view.TestEditor.setText('abc\\ndef')
       view.multiline.click()
 
@@ -48,14 +48,14 @@ describe 'Regex View', ->
       expect(view.TestEditor.isMini()).toBe false
 
     it 'splits the input line', ->
-      expect(view.TestEditor.getText()).toBe 'abc\ndef'
+      expect(view.TestEditor.getText()).toBe 'abc\\ndef'
 
     describe 'When unchecking the flag', ->
       beforeEach ->
         view.multiline.click()
 
       it 'shows a mini editor', ->
-        expect(view.TestEditor.isMini()).toBe true
+        expect(view.TestEditor.isMini()).toBe false
 
       it 'merges all input lines', ->
         expect(view.TestEditor.getText()).toBe 'abc\\ndef'
@@ -63,7 +63,7 @@ describe 'Regex View', ->
   describe 'When setting free-space flag', ->
 
     beforeEach ->
-      expect(view.RegexEditor.isMini()).toBe true
+      expect(view.RegexEditor.isMini()).toBe false
       view.RegexEditor.setText('abc\\ndef')
       view.xregexp.click()
       view.free_space.click()
@@ -73,14 +73,14 @@ describe 'Regex View', ->
       expect(view.RegexEditor.isMini()).toBe false
 
     it 'splits the input line', ->
-      expect(view.RegexEditor.getText()).toBe 'abc\ndef'
+      expect(view.RegexEditor.getText()).toBe 'abc\\ndef'
 
     describe 'When unchecking the flag', ->
       beforeEach ->
         view.free_space.click()
 
       it 'shows a mini editor', ->
-        expect(view.RegexEditor.isMini()).toBe true
+        expect(view.RegexEditor.isMini()).toBe false
 
       it 'merges all input lines', ->
         expect(view.RegexEditor.getText()).toBe 'abc\\ndef'

--- a/spec/xregex-spec.coffee
+++ b/spec/xregex-spec.coffee
@@ -45,22 +45,22 @@ describe 'XRegExp tests', ->
       expect(m).toEqual [
         {
           match: 'a'
-          named_groups: undefined
+          named_groups: { groups: undefined }
           groups: ['a']
         }
         {
           match: 'b'
-          named_groups: undefined
+          named_groups: { groups: undefined }
           groups: ['b']
         }
         {
           match: 'b'
-          named_groups: undefined
+          named_groups: { groups: undefined }
           groups: ['b']
         }
         {
           match: 'a'
-          named_groups: undefined
+          named_groups: { groups: undefined }
           groups: ['a']
         }
       ]
@@ -79,12 +79,12 @@ describe 'XRegExp tests', ->
       expect(m).toEqual [
         {
           match: 'abba'
-          named_groups: undefined
+          named_groups: { groups: undefined }
           groups: ['abba']
         }
         {
           match: 'baab'
-          named_groups: undefined
+          named_groups: { groups: undefined }
           groups: ['baab']
         }
       ]
@@ -104,6 +104,7 @@ describe 'XRegExp tests', ->
         {
           match: 'aabc'
           named_groups: {
+            groups: undefined
             group: 'aab'
           }
           groups: ['aab']
@@ -124,7 +125,7 @@ describe 'XRegExp tests', ->
       expect(m).toEqual [
         {
           match: 'aa\nbb'
-          named_groups: undefined
+          named_groups: { groups: undefined }
           groups: ['aa\nbb']
         }
       ]
@@ -144,6 +145,7 @@ describe 'XRegExp tests', ->
         {
           match: 'xregex-spec.coffee:134'
           named_groups: {
+            groups: undefined
             file: 'xregex-spec.coffee'
             row: '134'
           }


### PR DESCRIPTION
### panel issues
Toggle feature was actually show only, as a user I was confused how to hide and did not think to use Esc (which works).
I tried disabling and re-enabling the package, however due to a typo in the destructor the panel would stay there stuck even with Escape at that point.
I fixed the typo and split the "Toggle" into the Show and Hide commands instead. I'm partial to key bindings so I added a composite one.

**files affected:**
package.json
menus/regex-tester.cson
lib/regex-view.coffee
lib/main.coffee
keymaps/regex-tester.cson


### Mini editor issues
Switching to and from mini-triggering options e.g. multiline, causes the number pit to overlap text with no way to scroll and see it, and also the cursor size does not match lines anymore.
Switching back to mini also injects \n sequences for line breaks.
Seems that toggling the mini flag is not enough and more variables need to be recalculated.
In all honesty, I don't mind the non-mini mode at all times, so my fix for this is to just not have the mini mode. There is a number 1 and a bit of space reserved for it but I find it ok for a developer tool.

**files affected:**
lib/regex-view.coffee


### Atom crash
This may be due to the old version of XRegExp in use (most recent is 4.2.4), but Atom will hang for at least several minutes (never saw it recover), in the following conditions:
- Regex pattern blank
- XRegExp selected
- Global option selected
- at least one character in input
To prevent this, it seems enough to short circuit out of the update function if there is no pattern, at least I have not observed other episodes since.

**files affected:**
lib/regex-view.coffee